### PR TITLE
Clamp buffer capacity ceiling to allocator-safe limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,11 @@ Single-crate library with four modules:
   management. This is the core data structure.
 - **`read`**, `DynBufRead` trait: extends `BufRead` with buffer inspection and memory management.
 - **`reader`**, `DynBufReader<R>` + `DynBufReaderBuilder<R>`: wraps any `Read` with a `Buffer`,
-  implements `Read`, `BufRead`, `DynBufRead`, and `Seek`.
-- **`constants`**, `CHUNK_SIZE` (8 KiB), `DEFAULT_MAX_SIZE` (256 MiB), `THEORETICAL_MAX_SIZE`. All
-  buffer capacities are multiples of `CHUNK_SIZE`.
+  implements `Read`, `BufRead`, `DynBufRead`, and `Seek`. Treat this module as a work in
+  progress rather than a style/reference target.
+- **`constants`**, `CHUNK_SIZE` (8 KiB), `DEFAULT_MAX_CAPACITY` (256 MiB), and the internal
+  `MAX_SUPPORTED_CAPACITY` / `MAX_EXPONENTIAL_CAPACITY`. All buffer capacities are multiples of
+  `CHUNK_SIZE`; the internal max constants are technical ceilings, not public tuning knobs.
 
 Key design: `Buffer` does the heavy lifting; `DynBufReader` delegates to it while enforcing
 `max_capacity` and providing the trait impls. Tests live in sibling `tests.rs` files per module.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -26,7 +26,7 @@
 //! assert_eq!(&buffer.buf()[buffer.pos()..], b"World!");
 //! ```
 
-use crate::constants::{CHUNK_SIZE, THEORETICAL_MAX_SIZE};
+use crate::constants::{CHUNK_SIZE, MAX_EXPONENTIAL_CAPACITY, MAX_SUPPORTED_CAPACITY};
 use std::cmp;
 use std::io::{self, Read};
 
@@ -390,7 +390,7 @@ impl Buffer {
     ///
     /// This method implements the linear shrinking strategy used by the buffer. It rounds down
     /// the given capacity to the nearest multiple of [`CHUNK_SIZE`], with a minimum of
-    /// [`CHUNK_SIZE`] and a maximum of [`THEORETICAL_MAX_SIZE`].
+    /// [`CHUNK_SIZE`] and a maximum supported capacity.
     ///
     /// # Examples
     ///
@@ -408,7 +408,7 @@ impl Buffer {
     #[inline]
     #[expect(clippy::arithmetic_side_effects, reason = "Safe by bounds checks")]
     pub fn cap_down(capacity: usize) -> usize {
-        // Bounds checks clamp the result to `CHUNK_SIZE..=THEORETICAL_MAX_SIZE`
+        // Bounds checks clamp the result to the supported capacity range
 
         // Min bounds check
         if capacity <= CHUNK_SIZE {
@@ -416,8 +416,8 @@ impl Buffer {
         }
 
         // Max bounds check
-        if capacity >= THEORETICAL_MAX_SIZE {
-            return THEORETICAL_MAX_SIZE;
+        if capacity >= MAX_SUPPORTED_CAPACITY {
+            return MAX_SUPPORTED_CAPACITY;
         }
 
         // Round down `capacity` to the nearest multiple of `CHUNK_SIZE`
@@ -428,7 +428,7 @@ impl Buffer {
     ///
     /// This method implements the exponential growth strategy used by the buffer. It rounds up
     /// the given capacity to the nearest power-of-two multiple of [`CHUNK_SIZE`], with a minimum of
-    /// [`CHUNK_SIZE`] and a maximum of [`THEORETICAL_MAX_SIZE`].
+    /// [`CHUNK_SIZE`] and saturation at the implementation's supported maximum.
     ///
     /// # Examples
     ///
@@ -448,11 +448,11 @@ impl Buffer {
     #[inline]
     #[expect(clippy::arithmetic_side_effects, reason = "Safe by bounds checks")]
     pub fn cap_up(capacity: usize) -> usize {
-        // Bounds checks clamp the result to `CHUNK_SIZE..=THEORETICAL_MAX_SIZE`
+        // Bounds checks clamp the result to the supported capacity range
 
         // Max bounds check
-        if capacity > THEORETICAL_MAX_SIZE >> 1 {
-            return THEORETICAL_MAX_SIZE;
+        if capacity > MAX_EXPONENTIAL_CAPACITY {
+            return MAX_SUPPORTED_CAPACITY;
         }
 
         // Min bounds check
@@ -468,7 +468,7 @@ impl Buffer {
     ///
     /// This method provides linear capacity rounding, for precise capacity allocation. It rounds up
     /// the given capacity to the nearest multiple of [`CHUNK_SIZE`], with a minimum of
-    /// [`CHUNK_SIZE`] and a maximum of [`THEORETICAL_MAX_SIZE`].
+    /// [`CHUNK_SIZE`] and a maximum supported capacity.
     ///
     /// # Examples
     ///
@@ -487,11 +487,11 @@ impl Buffer {
     #[inline]
     #[expect(clippy::arithmetic_side_effects, reason = "Safe by bounds checks")]
     pub fn cap_up_linear(capacity: usize) -> usize {
-        // Bounds checks clamp the result to `CHUNK_SIZE..=THEORETICAL_MAX_SIZE`
+        // Bounds checks clamp the result to the supported capacity range
 
         // Max bounds check
-        if capacity > THEORETICAL_MAX_SIZE - CHUNK_SIZE {
-            return THEORETICAL_MAX_SIZE;
+        if capacity > MAX_SUPPORTED_CAPACITY - CHUNK_SIZE {
+            return MAX_SUPPORTED_CAPACITY;
         }
 
         // Min bounds check
@@ -505,7 +505,7 @@ impl Buffer {
 
     /// Grows the buffer capacity to the next power-of-two multiple of [`CHUNK_SIZE`].
     ///
-    /// The capacity grows exponentially up to a maximum of [`THEORETICAL_MAX_SIZE`].
+    /// The capacity grows exponentially until it reaches the supported maximum.
     ///
     /// # Examples
     ///
@@ -527,7 +527,7 @@ impl Buffer {
     ///
     /// If the buffer's current capacity already meets or exceeds `target`, no operation is
     /// performed. Otherwise, grows to the nearest power-of-two multiple of [`CHUNK_SIZE`] that
-    /// accommodates `target`, up to a maximum of [`THEORETICAL_MAX_SIZE`].
+    /// accommodates `target`, saturating at the supported maximum.
     ///
     /// # Examples
     ///
@@ -556,7 +556,7 @@ impl Buffer {
     ///
     /// If the buffer's current capacity already meets or exceeds `target`, no operation is
     /// performed. Otherwise, grows to the nearest multiple of [`CHUNK_SIZE`] that accommodates
-    /// `target`, up to a maximum of [`THEORETICAL_MAX_SIZE`].
+    /// `target`, saturating at the supported maximum.
     ///
     /// # Examples
     ///
@@ -726,7 +726,7 @@ impl Buffer {
     #[expect(clippy::arithmetic_side_effects, reason = "Safe by overflow check")]
     pub fn fill_amount(&mut self, mut reader: impl Read, amt: usize) -> io::Result<FillResult> {
         // Check if the requested amount exceeds what we can possibly accommodate
-        if amt > THEORETICAL_MAX_SIZE - self.len {
+        if amt > MAX_SUPPORTED_CAPACITY - self.len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "requested amount exceeds maximum buffer capacity",
@@ -790,7 +790,7 @@ impl Buffer {
     )]
     pub fn fill_exact(&mut self, mut reader: impl Read, amt: usize) -> io::Result<()> {
         // Check if the requested amount exceeds what we can possibly accommodate
-        if amt > THEORETICAL_MAX_SIZE - self.len {
+        if amt > MAX_SUPPORTED_CAPACITY - self.len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "requested amount exceeds maximum buffer capacity",

--- a/src/buffer/tests.rs
+++ b/src/buffer/tests.rs
@@ -7,7 +7,7 @@
 )]
 
 use super::*;
-use crate::constants::{CHUNK_SIZE, THEORETICAL_MAX_SIZE};
+use crate::constants::{CHUNK_SIZE, MAX_EXPONENTIAL_CAPACITY, MAX_SUPPORTED_CAPACITY};
 use std::io::{self, Cursor, Read};
 
 /// A reader that returns `Interrupted` once, then delegates to inner.
@@ -410,42 +410,46 @@ fn test_buffer_cap_down() {
     assert_eq!(Buffer::cap_down(20 * CHUNK_SIZE + 789), 20 * CHUNK_SIZE);
     assert_eq!(Buffer::cap_down(123 * CHUNK_SIZE + 1234), 123 * CHUNK_SIZE);
     assert_eq!(
-        Buffer::cap_down(THEORETICAL_MAX_SIZE - 1),
-        THEORETICAL_MAX_SIZE - CHUNK_SIZE
+        Buffer::cap_down(MAX_SUPPORTED_CAPACITY - 1),
+        MAX_SUPPORTED_CAPACITY - CHUNK_SIZE
+    );
+    assert_eq!(
+        Buffer::cap_down(MAX_SUPPORTED_CAPACITY),
+        MAX_SUPPORTED_CAPACITY
     );
 
-    /* Sizes above `THEORETICAL_MAX_SIZE` should round down to
-    `THEORETICAL_MAX_SIZE` as that's the max */
-    assert_eq!(Buffer::cap_down(usize::MAX), THEORETICAL_MAX_SIZE);
+    /* Sizes above `MAX_SUPPORTED_CAPACITY` should round down to
+    `MAX_SUPPORTED_CAPACITY` as that's the max */
+    assert_eq!(Buffer::cap_down(usize::MAX), MAX_SUPPORTED_CAPACITY);
     assert_eq!(
-        Buffer::cap_down(THEORETICAL_MAX_SIZE + 1234),
-        THEORETICAL_MAX_SIZE
+        Buffer::cap_down(MAX_SUPPORTED_CAPACITY + 1234),
+        MAX_SUPPORTED_CAPACITY
     );
     assert_eq!(
-        Buffer::cap_down(THEORETICAL_MAX_SIZE + 1),
-        THEORETICAL_MAX_SIZE
+        Buffer::cap_down(MAX_SUPPORTED_CAPACITY + 1),
+        MAX_SUPPORTED_CAPACITY
     );
 
     // Exact sizes should stay the same
     assert_eq!(Buffer::cap_down(3 * CHUNK_SIZE), 3 * CHUNK_SIZE);
     assert_eq!(
-        Buffer::cap_down(THEORETICAL_MAX_SIZE - CHUNK_SIZE),
-        THEORETICAL_MAX_SIZE - CHUNK_SIZE
+        Buffer::cap_down(MAX_SUPPORTED_CAPACITY - CHUNK_SIZE),
+        MAX_SUPPORTED_CAPACITY - CHUNK_SIZE
     );
 }
 
 #[test]
 fn test_buffer_cap_up() {
-    /* Sizes above `THEORETICAL_MAX_SIZE` should round down to
-    `THEORETICAL_MAX_SIZE` as that's the max */
-    assert_eq!(Buffer::cap_up(usize::MAX), THEORETICAL_MAX_SIZE);
+    /* Sizes above `MAX_SUPPORTED_CAPACITY` should round down to
+    `MAX_SUPPORTED_CAPACITY` as that's the max */
+    assert_eq!(Buffer::cap_up(usize::MAX), MAX_SUPPORTED_CAPACITY);
     assert_eq!(
-        Buffer::cap_up(THEORETICAL_MAX_SIZE + 1234),
-        THEORETICAL_MAX_SIZE
+        Buffer::cap_up(MAX_SUPPORTED_CAPACITY + 1234),
+        MAX_SUPPORTED_CAPACITY
     );
     assert_eq!(
-        Buffer::cap_up(THEORETICAL_MAX_SIZE + 1),
-        THEORETICAL_MAX_SIZE
+        Buffer::cap_up(MAX_SUPPORTED_CAPACITY + 1),
+        MAX_SUPPORTED_CAPACITY
     );
 
     // Other values should round up to the nearest power-of-2 multiple of `CHUNK_SIZE`
@@ -455,12 +459,12 @@ fn test_buffer_cap_up() {
     assert_eq!(Buffer::cap_up(20 * CHUNK_SIZE - 789), 32 * CHUNK_SIZE);
     assert_eq!(Buffer::cap_up(123 * CHUNK_SIZE - 1234), 128 * CHUNK_SIZE);
     assert_eq!(
-        Buffer::cap_up(THEORETICAL_MAX_SIZE - 1),
-        THEORETICAL_MAX_SIZE
+        Buffer::cap_up(MAX_SUPPORTED_CAPACITY - 1),
+        MAX_SUPPORTED_CAPACITY
     );
     assert_eq!(
-        Buffer::cap_up((THEORETICAL_MAX_SIZE >> 1) + 1),
-        THEORETICAL_MAX_SIZE
+        Buffer::cap_up(MAX_EXPONENTIAL_CAPACITY + 1),
+        MAX_SUPPORTED_CAPACITY
     );
 
     // Sizes below `CHUNK_SIZE` should round up to `CHUNK_SIZE` as that's the min
@@ -470,23 +474,23 @@ fn test_buffer_cap_up() {
     // Exact sizes should stay the same
     assert_eq!(Buffer::cap_up(4 * CHUNK_SIZE), 4 * CHUNK_SIZE);
     assert_eq!(
-        Buffer::cap_up(THEORETICAL_MAX_SIZE >> 1),
-        THEORETICAL_MAX_SIZE >> 1
+        Buffer::cap_up(MAX_EXPONENTIAL_CAPACITY),
+        MAX_EXPONENTIAL_CAPACITY
     );
 }
 
 #[test]
 fn test_buffer_cap_up_linear() {
-    /* Sizes above `THEORETICAL_MAX_SIZE` should round down to
-    `THEORETICAL_MAX_SIZE` as that's the max */
-    assert_eq!(Buffer::cap_up_linear(usize::MAX), THEORETICAL_MAX_SIZE);
+    /* Sizes above `MAX_SUPPORTED_CAPACITY` should round down to
+    `MAX_SUPPORTED_CAPACITY` as that's the max */
+    assert_eq!(Buffer::cap_up_linear(usize::MAX), MAX_SUPPORTED_CAPACITY);
     assert_eq!(
-        Buffer::cap_up_linear(THEORETICAL_MAX_SIZE + 1234),
-        THEORETICAL_MAX_SIZE
+        Buffer::cap_up_linear(MAX_SUPPORTED_CAPACITY + 1234),
+        MAX_SUPPORTED_CAPACITY
     );
     assert_eq!(
-        Buffer::cap_up_linear(THEORETICAL_MAX_SIZE + 1),
-        THEORETICAL_MAX_SIZE
+        Buffer::cap_up_linear(MAX_SUPPORTED_CAPACITY + 1),
+        MAX_SUPPORTED_CAPACITY
     );
 
     // Other values should round up to nearest linear multiple of `CHUNK_SIZE`
@@ -502,12 +506,12 @@ fn test_buffer_cap_up_linear() {
         123 * CHUNK_SIZE
     );
     assert_eq!(
-        Buffer::cap_up_linear(THEORETICAL_MAX_SIZE - 1),
-        THEORETICAL_MAX_SIZE // Note: `THEORETICAL_MAX_SIZE` is a multiple of `CHUNK_SIZE`
+        Buffer::cap_up_linear(MAX_SUPPORTED_CAPACITY - 1),
+        MAX_SUPPORTED_CAPACITY // Note: `MAX_SUPPORTED_CAPACITY` is a multiple of `CHUNK_SIZE`
     );
     assert_eq!(
-        Buffer::cap_up_linear(THEORETICAL_MAX_SIZE - CHUNK_SIZE + 1),
-        THEORETICAL_MAX_SIZE
+        Buffer::cap_up_linear(MAX_SUPPORTED_CAPACITY - CHUNK_SIZE + 1),
+        MAX_SUPPORTED_CAPACITY
     );
 
     // Sizes below `CHUNK_SIZE` should round up to `CHUNK_SIZE` as that's the min
@@ -517,8 +521,12 @@ fn test_buffer_cap_up_linear() {
     // Exact sizes should stay the same
     assert_eq!(Buffer::cap_up_linear(3 * CHUNK_SIZE), 3 * CHUNK_SIZE);
     assert_eq!(
-        Buffer::cap_up_linear(THEORETICAL_MAX_SIZE - CHUNK_SIZE),
-        THEORETICAL_MAX_SIZE - CHUNK_SIZE
+        Buffer::cap_up_linear(MAX_SUPPORTED_CAPACITY - CHUNK_SIZE),
+        MAX_SUPPORTED_CAPACITY - CHUNK_SIZE
+    );
+    assert_eq!(
+        Buffer::cap_up_linear(MAX_SUPPORTED_CAPACITY),
+        MAX_SUPPORTED_CAPACITY
     );
 }
 
@@ -843,10 +851,10 @@ fn test_buffer_fill_amount() {
     buffer.discard();
 
     /* Test error when requesting more than the buffer can accommodate. The buffer cannot grow
-    beyond `THEORETICAL_MAX_SIZE`, so `amt > THEORETICAL_MAX_SIZE - self.len` is an unfulfillable
-    request */
+    beyond `MAX_SUPPORTED_CAPACITY`, so
+    `amt > MAX_SUPPORTED_CAPACITY - self.len` is an unfulfillable request. */
     let cur = Cursor::new(&data);
-    let result = buffer.fill_amount(cur, THEORETICAL_MAX_SIZE + 1);
+    let result = buffer.fill_amount(cur, MAX_SUPPORTED_CAPACITY + 1);
 
     // We should get an InvalidInput error
     assert!(result.is_err());
@@ -859,7 +867,7 @@ fn test_buffer_fill_amount() {
     let cur = Cursor::new(&data);
     let result = buffer.fill_amount(
         cur,
-        THEORETICAL_MAX_SIZE, // Now this exceeds remaining capacity
+        MAX_SUPPORTED_CAPACITY, // Now this exceeds remaining capacity
     );
 
     // We should get an InvalidInput error
@@ -921,10 +929,10 @@ fn test_buffer_fill_exact() {
     buffer.discard();
 
     /* Test error when requesting more than the buffer can accommodate. The buffer cannot grow
-    beyond `THEORETICAL_MAX_SIZE`, so `amt > THEORETICAL_MAX_SIZE - self.len` is an unfulfillable
-    request */
+    beyond `MAX_SUPPORTED_CAPACITY`, so
+    `amt > MAX_SUPPORTED_CAPACITY - self.len` is an unfulfillable request. */
     let cur = Cursor::new(&data);
-    let result = buffer.fill_exact(cur, THEORETICAL_MAX_SIZE + 1);
+    let result = buffer.fill_exact(cur, MAX_SUPPORTED_CAPACITY + 1);
 
     // We should get an InvalidInput error
     assert!(result.is_err());
@@ -937,7 +945,7 @@ fn test_buffer_fill_exact() {
     let cur = Cursor::new(&data);
     let result = buffer.fill_exact(
         cur,
-        THEORETICAL_MAX_SIZE, // Now this exceeds remaining capacity
+        MAX_SUPPORTED_CAPACITY, // Now this exceeds remaining capacity
     );
 
     // We should get an InvalidInput error

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,9 +7,10 @@
 //! The following mathematical relationships must hold between the constants:
 //!
 //! - [`CHUNK_SIZE`] is a power of 2 and at least 8 KiB
-//! - [`DEFAULT_MAX_SIZE`] and [`THEORETICAL_MAX_SIZE`] are both power-of-two multiples of
-//!   `CHUNK_SIZE`
-//! - `CHUNK_SIZE < DEFAULT_MAX_SIZE < THEORETICAL_MAX_SIZE`
+//! - [`DEFAULT_MAX_CAPACITY`] is a power-of-two multiple of `CHUNK_SIZE`
+//! - [`MAX_SUPPORTED_CAPACITY`] is a multiple of `CHUNK_SIZE`
+//! - [`MAX_SUPPORTED_CAPACITY`] is the largest aligned capacity supported by the implementation
+//! - `CHUNK_SIZE < DEFAULT_MAX_CAPACITY < MAX_SUPPORTED_CAPACITY`
 
 /// Buffer chunk size. (8 KiB)
 ///
@@ -19,19 +20,25 @@
 /// Buffer capacity is always a multiple of this value, making it also the minimum possible size.
 pub const CHUNK_SIZE: usize = 1 << 13; // 2^13 = 8 KiB
 
-/// Default maximum buffer size (256 MiB) when no limit is specified.
+/// Default maximum buffer capacity (256 MiB) when no limit is specified.
 ///
 /// Provides a reasonable upper bound for most use cases while preventing runaway memory usage.
-pub const DEFAULT_MAX_SIZE: usize = CHUNK_SIZE * (1 << 15); // CHUNK_SIZE * 2^15 = 256 MiB
+pub const DEFAULT_MAX_CAPACITY: usize = CHUNK_SIZE * (1 << 15); // CHUNK_SIZE * 2^15 = 256 MiB
 
-/// Theoretical maximum buffer size.
+/// Largest aligned capacity supported by the implementation.
 ///
-/// This is a hardware/platform limit. Used to have an upper bound against unreasonable user input.
-/// Its value is the largest power-of-two multiple of [`CHUNK_SIZE`] that fits in usize,
-/// representing the theoretical maximum reachable through exponential growth.
+/// This is an internal technical ceiling derived from the backing `Vec<u8>` allocation model,
+/// rounded down from the platform's signed-index ceiling to a [`CHUNK_SIZE`] multiple.
 ///
-/// Equals `usize::MAX / 2 + 1` just expressed in terms of `CHUNK_SIZE`.
-pub const THEORETICAL_MAX_SIZE: usize = CHUNK_SIZE * (1 << CHUNK_SIZE.leading_zeros());
+/// It is not a sane operating target or public tuning value.
+pub(crate) const MAX_SUPPORTED_CAPACITY: usize = ((usize::MAX >> 1) / CHUNK_SIZE) * CHUNK_SIZE;
+
+/// Largest power-of-two multiple of [`CHUNK_SIZE`] below the allocator ceiling.
+///
+/// Used internally to determine when exponential growth must saturate to
+/// [`MAX_SUPPORTED_CAPACITY`] instead of rounding to the next power-of-two capacity.
+pub(crate) const MAX_EXPONENTIAL_CAPACITY: usize =
+    ((MAX_SUPPORTED_CAPACITY / CHUNK_SIZE).next_power_of_two() >> 1) * CHUNK_SIZE;
 
 #[cfg(test)]
 mod tests;

--- a/src/constants/tests.rs
+++ b/src/constants/tests.rs
@@ -17,29 +17,41 @@ fn test_invariant() {
     // CHUNK_SIZE is a power of two
     assert_eq!(CHUNK_SIZE & (CHUNK_SIZE - 1), 0);
 
-    // DEFAULT_MAX_SIZE is larger than CHUNK_SIZE
-    assert!(DEFAULT_MAX_SIZE > CHUNK_SIZE);
+    // DEFAULT_MAX_CAPACITY is larger than CHUNK_SIZE
+    assert!(DEFAULT_MAX_CAPACITY > CHUNK_SIZE);
 
-    // DEFAULT_MAX_SIZE is a multiple of CHUNK_SIZE
-    assert_eq!(DEFAULT_MAX_SIZE % CHUNK_SIZE, 0);
+    // DEFAULT_MAX_CAPACITY is a multiple of CHUNK_SIZE
+    assert_eq!(DEFAULT_MAX_CAPACITY % CHUNK_SIZE, 0);
 
-    // DEFAULT_MAX_SIZE is a power of two (transitive)
-    assert_eq!(DEFAULT_MAX_SIZE & (DEFAULT_MAX_SIZE - 1), 0);
+    // DEFAULT_MAX_CAPACITY is a power of two (transitive)
+    assert_eq!(DEFAULT_MAX_CAPACITY & (DEFAULT_MAX_CAPACITY - 1), 0);
 
-    // DEFAULT_MAX_SIZE is a power of two multiple of CHUNK_SIZE
-    let k = DEFAULT_MAX_SIZE / CHUNK_SIZE;
+    // DEFAULT_MAX_CAPACITY is a power of two multiple of CHUNK_SIZE
+    let k = DEFAULT_MAX_CAPACITY / CHUNK_SIZE;
     assert_eq!(k & (k - 1), 0);
 
-    // THEORETICAL_MAX_SIZE is larger than DEFAULT_MAX_SIZE
-    assert!(THEORETICAL_MAX_SIZE > DEFAULT_MAX_SIZE);
+    // MAX_SUPPORTED_CAPACITY is larger than DEFAULT_MAX_CAPACITY
+    assert!(MAX_SUPPORTED_CAPACITY > DEFAULT_MAX_CAPACITY);
 
-    // THEORETICAL_MAX_SIZE is a multiple of CHUNK_SIZE
-    assert_eq!(THEORETICAL_MAX_SIZE % CHUNK_SIZE, 0);
+    // MAX_SUPPORTED_CAPACITY is a multiple of CHUNK_SIZE
+    assert_eq!(MAX_SUPPORTED_CAPACITY % CHUNK_SIZE, 0);
 
-    // THEORETICAL_MAX_SIZE is a power of two (transitive)
-    assert_eq!(THEORETICAL_MAX_SIZE & (THEORETICAL_MAX_SIZE - 1), 0);
+    let signed_index_ceiling = usize::MAX >> 1;
 
-    // THEORETICAL_MAX_SIZE is a power of two multiple of CHUNK_SIZE
-    let k = THEORETICAL_MAX_SIZE / CHUNK_SIZE;
+    // MAX_SUPPORTED_CAPACITY does not exceed what Vec<u8> can index safely
+    assert!(MAX_SUPPORTED_CAPACITY <= signed_index_ceiling);
+
+    // MAX_SUPPORTED_CAPACITY is exactly the aligned allocator ceiling
+    let expected = (signed_index_ceiling / CHUNK_SIZE) * CHUNK_SIZE;
+    assert_eq!(MAX_SUPPORTED_CAPACITY, expected);
+
+    // MAX_EXPONENTIAL_CAPACITY is the last exact exponential growth step below the ceiling
+    assert!(MAX_EXPONENTIAL_CAPACITY <= MAX_SUPPORTED_CAPACITY);
+    assert_eq!(MAX_EXPONENTIAL_CAPACITY % CHUNK_SIZE, 0);
+    let k = MAX_EXPONENTIAL_CAPACITY / CHUNK_SIZE;
     assert_eq!(k & (k - 1), 0);
+    assert!(MAX_EXPONENTIAL_CAPACITY < MAX_SUPPORTED_CAPACITY);
+
+    // The next aligned step would exceed the allocator ceiling
+    assert!(MAX_SUPPORTED_CAPACITY > signed_index_ceiling - CHUNK_SIZE);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //! - [`buffer::Buffer`]: the standalone buffer for users who want direct control without wrapping a
 //!   reader.
 //! - [`constants`]: buffer size constants ([`CHUNK_SIZE`](constants::CHUNK_SIZE),
-//!   [`DEFAULT_MAX_SIZE`](constants::DEFAULT_MAX_SIZE)) used throughout the crate.
+//!   [`DEFAULT_MAX_CAPACITY`](constants::DEFAULT_MAX_CAPACITY)) used throughout the crate.
 
 pub mod buffer;
 pub mod constants;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,6 @@
 use crate::DynBufRead;
 use crate::buffer::Buffer;
-use crate::constants::DEFAULT_MAX_SIZE;
+use crate::constants::DEFAULT_MAX_CAPACITY;
 use std::fmt;
 use std::io::{self, BufRead, Read, Seek, SeekFrom};
 
@@ -31,7 +31,7 @@ impl<R: fmt::Debug + ?Sized> fmt::Debug for DynBufReader<R> {
 impl<R: Read> DynBufReader<R> {
     /// Creates a new `DynBufReader` with default configuration.
     ///
-    /// The buffer starts at the default capacity and can grow up to [`DEFAULT_MAX_SIZE`].
+    /// The buffer starts at the default capacity and can grow up to [`DEFAULT_MAX_CAPACITY`].
     pub fn new(reader: R) -> DynBufReader<R> {
         DynBufReader::builder(reader).build()
     }
@@ -65,7 +65,7 @@ impl<R: Read> DynBufReaderBuilder<R> {
         self
     }
 
-    /// Sets the maximum buffer capacity. Defaults to [`DEFAULT_MAX_SIZE`].
+    /// Sets the maximum buffer capacity. Defaults to [`DEFAULT_MAX_CAPACITY`].
     pub fn max_capacity(mut self, cap: usize) -> Self {
         self.max_capacity = Some(cap);
         self
@@ -79,7 +79,7 @@ impl<R: Read> DynBufReaderBuilder<R> {
         };
         let max_capacity = self
             .max_capacity
-            .map_or(DEFAULT_MAX_SIZE, Buffer::cap_up)
+            .map_or(DEFAULT_MAX_CAPACITY, Buffer::cap_up)
             .max(buffer.cap());
 
         DynBufReader {

--- a/src/reader/tests.rs
+++ b/src/reader/tests.rs
@@ -22,7 +22,7 @@ fn test_reader_new() {
 
     // Check internal state matches expectations
     assert_eq!(reader.buffer, Buffer::default());
-    assert_eq!(reader.max_capacity, DEFAULT_MAX_SIZE);
+    assert_eq!(reader.max_capacity, DEFAULT_MAX_CAPACITY);
     assert_eq!(reader.reader, Cursor::default());
 }
 
@@ -50,7 +50,7 @@ fn test_reader_builder() {
     // Check internal state matches expectations
     assert_eq!(reader.buffer, Buffer::with_capacity(initial_capacity));
     assert_eq!(reader.buffer.cap(), 3 * CHUNK_SIZE);
-    assert_eq!(reader.max_capacity, DEFAULT_MAX_SIZE);
+    assert_eq!(reader.max_capacity, DEFAULT_MAX_CAPACITY);
     assert_eq!(reader.reader, Cursor::default());
 
     // Create with both initial_capacity and max_capacity
@@ -669,7 +669,7 @@ fn test_reader_max_capacity() {
     // Default max capacity
     let cur: Cursor<&str> = Cursor::default();
     let reader = DynBufReader::new(cur);
-    assert_eq!(reader.max_capacity(), DEFAULT_MAX_SIZE);
+    assert_eq!(reader.max_capacity(), DEFAULT_MAX_CAPACITY);
 
     // Custom max capacity
     let cur: Cursor<&str> = Cursor::default();


### PR DESCRIPTION
## Summary
- clamp the internal max buffer capacity to the allocator-safe signed-index ceiling instead of the old purely mathematical limit
- introduce a dedicated exponential-growth threshold so `Buffer::cap_up` saturates correctly under the new non-power-of-two maximum
- rename the capacity constants for clearer vocabulary and update related docs/tests

## Details
This changes the internal maximum capacity model from the old `THEORETICAL_MAX_SIZE` approach to:
- `DEFAULT_MAX_CAPACITY`
- `MAX_SUPPORTED_CAPACITY`
- `MAX_EXPONENTIAL_CAPACITY`

`MAX_SUPPORTED_CAPACITY` is now the largest `CHUNK_SIZE`-aligned capacity supported by the backing `Vec<u8>` allocation model. `MAX_EXPONENTIAL_CAPACITY` is the last exact power-of-two growth step below that ceiling.

With that split in place, `Buffer` rounding and preflight checks now clamp against the right threshold:
- `cap_down` and `cap_up_linear` saturate at `MAX_SUPPORTED_CAPACITY`
- `cap_up` saturates when a request exceeds `MAX_EXPONENTIAL_CAPACITY`
- `fill_amount` and `fill_exact` reject requests beyond the remaining supported capacity

The PR also updates the constant/docs wording so these limits are clearly internal technical ceilings rather than sane user-facing tuning targets, and refreshes the stale `AGENTS.md` guidance accordingly.

## Verification
- `cargo test --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings`

Fixes #4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified buffer capacity limit documentation with updated constant naming and improved descriptions of maximum capacity constraints.

* **Refactor**
  * Updated internal buffer capacity constants and adjusted capacity management operations to enforce stricter maximum capacity boundary enforcement across all sizing functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->